### PR TITLE
Fix broken colors section in git page

### DIFF
--- a/utilities/git.mdx
+++ b/utilities/git.mdx
@@ -77,18 +77,3 @@ git config --global user.email "romain@dorgueil.net"
 * [Original article with my git config and aliases](http://romain.dorgueil.net/blog/en/git/2014/12/16/git-config.html)
 * Github flow: [Understanding the GitHub Flow](https://guides.github.com/introduction/flow/)
 * Git-flow: [A Successful Git Branching Model](http://nvie.com/posts/a-successful-git-branching-model/)
-
-## *Deprecated* - Colors (not required after git 1.8.4)
-
-.. code-block:: shell
-
-	git config --global color.branch auto
-	git config --global color.diff auto
-	git config --global color.interactive auto
-	git config --global color.status auto
-
-or
-
-.. code-block:: shell
-
-	git config --global color.ui true


### PR DESCRIPTION
## Summary
- Removes the deprecated colors section from utilities/git.mdx that was broken due to reStructuredText syntax not working in MDX format
- This section is no longer needed as Git 1.8.4+ handles colors automatically

## Test plan
- [x] Verified the MDX file renders correctly without syntax errors
- [x] Confirmed the remaining content is intact and properly formatted

Fixes #4