### PR TITLE
feat: Kubernetes tooling page (kubectx, kubens, k9s, stern)

### DIFF
--- a/system/kubernetes/index.mdx
+++ b/system/kubernetes/index.mdx
@@ -9,6 +9,10 @@ http://kubernetes.io/
 
 Introduction: https://docs.google.com/presentation/d/1zrfVlE5r61ZNQrmXKx5gJmBcXnoa_WerHEnTxu5SMco
 
+## Daily tooling
+
+<Link to="tooling" /> - the CLI toolbox around kubectl (kubectx, kubens, k9s, stern).
+
 ## Books and readings
 
 * Start with https://kubernetes.io/docs/tutorials/kubernetes-basics/

--- a/system/kubernetes/tooling.mdx
+++ b/system/kubernetes/tooling.mdx
@@ -1,0 +1,83 @@
+---
+title: Kubernetes tooling
+description: The daily CLI toolbox around kubectl - context and namespace switching (kubectx, kubens), a terminal UI (k9s), and multi-pod log tailing (stern).
+checkedOn: 2026-07-20
+---
+
+The commands below are the everyday companions to `kubectl`. Verified with kubectx/kubens (ahmetb), k9s v0.32.5 and stern 1.30.0.
+
+## kubectx and kubens
+
+[kubectx](https://github.com/ahmetb/kubectx) switches between clusters (contexts), [kubens](https://github.com/ahmetb/kubectx) switches namespaces. They ship together.
+
+Install (macOS):
+
+```
+brew install kubectx
+```
+
+kubectx:
+
+```
+kubectx                 # list contexts
+kubectx <name>          # switch to context <name>
+kubectx -               # switch back to the previous context
+kubectx -c              # print the current context name
+kubectx <new>=<old>     # rename context <old> to <new>
+kubectx -d <name>       # delete a context
+kubectx -u              # unset the current context
+```
+
+kubens:
+
+```
+kubens                  # list namespaces in the current context
+kubens <name>           # set the active namespace
+kubens -                # switch back to the previous namespace
+kubens -c               # print the current namespace
+```
+
+With [fzf](https://github.com/junegunn/fzf) installed, running `kubectx` or `kubens` with no argument opens an interactive picker.
+
+## k9s
+
+[k9s](https://github.com/derailed/k9s) (v0.32.5) is a terminal UI to observe and manage a cluster: navigate resources, read logs, exec into pods, delete objects, all from the keyboard.
+
+Install:
+
+```
+brew install k9s
+```
+
+Launch with `k9s`. Inside:
+
+* `:` opens the command prompt, then a resource name (`:pods`, `:deploy`, `:svc`, `:ns`, ...).
+* `/` filters the current view.
+* `:ctx` switches context, `:ns` switches namespace.
+* `?` lists the shortcuts (they vary by view and version), `:q` quits.
+
+## stern
+
+[stern](https://github.com/stern/stern) (1.30.0) tails logs from multiple pods and containers at once, which `kubectl logs` cannot do. The pod query is a regular expression matched against pod names.
+
+Install:
+
+```
+brew install stern
+```
+
+```
+stern <pod-query>                 # tail all pods matching the query
+stern <pod-query> -n <namespace>  # limit to a namespace
+stern <pod-query> -A              # across all namespaces
+stern -l app=api                  # select by label instead of by name
+stern <query> -c <container>      # a specific container (regex) in multi-container pods
+stern <query> --tail 100          # start from the last 100 lines
+stern <query> -t                  # prefix each line with a timestamp
+stern <query> --no-follow         # print existing logs and exit
+```
+
+## See also
+
+* `kubectl` plugins via [krew](https://github.com/kubernetes-sigs/krew), the kubectl plugin manager.
+* `kustomize`, the overlay tool built into `kubectl` (`kubectl kustomize`) and available standalone ([kubernetes-sigs/kustomize](https://github.com/kubernetes-sigs/kustomize)).


### PR DESCRIPTION
First EXPAND page from the wiki triage (RDN_WIKI_IDEAS §1), opened as a **draft for your review** — please rewrite in your voice / trim as you see fit before merging.

## What it is
A new `/wiki/system/kubernetes/tooling/` page: the daily CLI toolbox around `kubectl`. To host it as a child, `system/kubernetes.mdx` moves to `system/kubernetes/index.mdx` (URL unchanged) and links the new page from a "Daily tooling" section.

## Verification (empirical, this session)
Commands checked against the actually-installed tools:
- **kubectx / kubens** — usage from `--help` (list/switch/rename/delete, `-` previous, `-c` current, `-u` unset).
- **k9s v0.32.5** — `:` prompt, `/` filter, `:ctx`/`:ns`, `?` help (I kept k9s shortcuts minimal since I couldn't run it against a live cluster here — worth a glance from you, you use it daily).
- **stern 1.30.0** — flags `-A`, `-n`, `-l`, `-c`, `-t`, `--tail`, `--no-follow` all verified from `--help`.
- `kubectl` plugins (krew) and `kustomize` are doc-cited in "See also" (the sandbox `kubectl` is broken by a gcloud auth plugin).

`checkedOn: 2026-07-20` is set, so it gets a real `dateModified` + sitemap `lastmod`.

## Notes
- No prose was carried from elsewhere; this is a fresh draft to the tmux quality bar, for you to make yours.
- Next candidates from RDN_WIKI_IDEAS on the same section: a **Helm** page and expanding the **kubernetes** hub with recipes.