### PR TITLE
docs: python - finalize section (hub, placeholders, verified scaffolds, theme)

### DIFF
--- a/python/bonobo.mdx
+++ b/python/bonobo.mdx
@@ -5,6 +5,8 @@ description: "Bonobo is an [extract-transform-load toolkit for python 3.5+ ](htt
 
 Bonobo is an [extract-transform-load toolkit for python 3.5+ ](https://bonobo-project.org/), aiming for simplicity.
 
+> **Note**: not actively maintained at the moment.
+
 Bonobo is a rewrite / cleanup of rdc.etl for Python 3.5+. It's a work in progress, but already useable. Maybe.
 
 ## Quick start

--- a/python/descriptors.mdx
+++ b/python/descriptors.mdx
@@ -39,13 +39,13 @@ class Positive:
             raise ValueError(f"{self._name[1:]} must be > 0")
         setattr(obj, self._name, value)
 
-class Account:
-    balance = Positive()
-    def __init__(self, balance):
-        self.balance = balance   # goes through Positive.__set__
+class Knight:
+    honour = Positive()
+    def __init__(self, honour):
+        self.honour = honour   # goes through Positive.__set__
 ```
 
-Assigning a non-positive `balance` raises `ValueError`, from `__init__` or anywhere else.
+Assigning a non-positive `honour` raises `ValueError`, from `__init__` or anywhere else.
 
 ## Data vs non-data descriptors
 

--- a/python/fastapi.mdx
+++ b/python/fastapi.mdx
@@ -1,0 +1,10 @@
+---
+title: FastAPI
+description: FastAPI - an ASGI web framework built on Starlette and Pydantic, deriving validation and OpenAPI docs from type hints. Notes to come.
+---
+
+FastAPI is an ASGI web framework built on <Link to="starlette" /> and Pydantic. It derives request validation, serialization and OpenAPI docs from ordinary type hints.
+
+Notes to come: routing, dependency injection, request and response models, background tasks, testing.
+
+* https://fastapi.tiangolo.com/

--- a/python/index.mdx
+++ b/python/index.mdx
@@ -7,8 +7,24 @@ Python is a widely used high-level, general-purpose, interpreted, dynamic progra
 
 ## Language deep dives
 
-* <Link to="decorators" /> - wrapping callables (with `functools.wraps`, arguments, stacking).
+* <Link to="decorators" /> - wrapping callables (with `functools.wraps`, arguments, stacking, and the kinds of decorators).
 * <Link to="descriptors" /> - the `__get__`/`__set__` protocol behind properties, methods and ORM fields.
+
+## Web frameworks
+
+* <Link to="django" /> - the batteries-included framework (see also <Link to="django/authentication" />).
+* <Link to="fastapi" /> and <Link to="starlette" /> - the async, type-hinted stack (FastAPI builds on Starlette).
+* <Link to="jinja2" /> - templating.
+* <Link to="wtforms" /> - form handling and validation (a legacy choice today).
+
+## Data and libraries
+
+* <Link to="pandas" />, <Link to="jupyter" />, <Link to="bokeh" /> - data wrangling, notebooks, plotting.
+* <Link to="sqlalchemy" /> - SQL toolkit and ORM (see also <Link to="/database" />).
+* <Link to="aiohttp" /> - async HTTP client and server.
+* <Link to="testing" /> - pytest in practice.
+* <Link to="odoo" /> - the ERP framework.
+* <Link to="bonobo" /> - ETL toolkit (not maintained for now).
 
 ## Cookbook
 

--- a/python/index.mdx
+++ b/python/index.mdx
@@ -19,9 +19,8 @@ Python is a widely used high-level, general-purpose, interpreted, dynamic progra
 
 ## Data and libraries
 
-* <Link to="pandas" />, <Link to="jupyter" />, <Link to="bokeh" /> - data wrangling, notebooks, plotting.
+* <Link to="pandas" />, <Link to="jupyter" /> - data wrangling, notebooks.
 * <Link to="sqlalchemy" /> - SQL toolkit and ORM (see also <Link to="/database" />).
-* <Link to="aiohttp" /> - async HTTP client and server.
 * <Link to="testing" /> - pytest in practice.
 * <Link to="odoo" /> - the ERP framework.
 * <Link to="bonobo" /> - ETL toolkit (not maintained for now).

--- a/python/pandas.mdx
+++ b/python/pandas.mdx
@@ -1,7 +1,6 @@
 ---
 title: Pandas
 description: "Data analysis library for Python: DataFrames, indexing, and IO tools."
-checkedOn: 2026-07-10
 ---
 
 Pandas is an open source, BSD-licensed library providing high-performance, easy-to-use data
@@ -60,6 +59,60 @@ df = df.set_index('screen_name')
 ```
 
 `set_index` returns a new DataFrame, so assign it back (or pass `inplace=True`).
+
+### A frame to work with
+
+```python
+import pandas as pd
+
+df = pd.DataFrame({
+    "knight": ["Arthur", "Lancelot", "Galahad", "Robin"],
+    "quest": ["grail", "grail", "grail", "flee"],
+    "colour": ["blue", "blue", "yellow", "brave"],
+    "coconuts": [2, 0, 1, 3],
+})
+speeds = pd.DataFrame({"knight": ["Arthur", "Robin"], "mph": [11, 9]})
+```
+
+### Select rows with a boolean mask
+
+```python
+grail = df.loc[df["quest"] == "grail", ["knight", "coconuts"]]
+```
+
+`.loc[rows, cols]` selects by label; here the row part is a boolean Series and the column part a list.
+
+### Group and aggregate
+
+```python
+by_colour = df.groupby("colour")["coconuts"].sum().sort_values(ascending=False)
+```
+
+### Merge two frames
+
+```python
+joined = df.merge(speeds, on="knight", how="left")
+```
+
+`how` is one of `left`, `right`, `inner`, `outer`.
+
+### Count occurrences
+
+```python
+counts = df["quest"].value_counts()
+```
+
+### Parse and filter dates
+
+```python
+events = pd.DataFrame({
+    "when": pd.to_datetime(["0932-01-01", "0932-06-01"], format="%Y-%m-%d"),
+    "n": [1, 2],
+})
+recent = events[events["when"] >= "0932-03-01"]
+```
+
+Pass an explicit `format` so parsing is consistent and fast.
 
 ## Links and references
 

--- a/python/sqlalchemy.mdx
+++ b/python/sqlalchemy.mdx
@@ -1,7 +1,6 @@
 ---
 title: SQLAlchemy
 description: "SQLAlchemy notes: turn on engine SQL logging, and the Core / ORM split."
-checkedOn: 2026-07-08
 ---
 
 This page is a work in progress.
@@ -19,6 +18,35 @@ logging.basicConfig()
 logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 engine = create_engine('sqlite:///basics.sqlite')
 ```
+
 ## Object Relational Mapper
+
+Declarative model, engine and a query (SQLAlchemy 2.0 style):
+
+```python
+from sqlalchemy import create_engine, select, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, Session
+
+class Base(DeclarativeBase):
+    pass
+
+class Knight(Base):
+    __tablename__ = "knights"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(50))
+    quest: Mapped[str | None]
+
+engine = create_engine("sqlite://")
+Base.metadata.create_all(engine)
+
+with Session(engine) as session:
+    session.add(Knight(name="Arthur", quest="grail"))
+    session.commit()
+
+with Session(engine) as session:
+    knight = session.scalars(
+        select(Knight).where(Knight.quest == "grail")
+    ).one()
+```
 
 ## Miscellaneous

--- a/python/starlette.mdx
+++ b/python/starlette.mdx
@@ -1,0 +1,10 @@
+---
+title: Starlette
+description: Starlette - the lightweight ASGI toolkit (routing, middleware, websockets, background tasks) that FastAPI is built on. Notes to come.
+---
+
+Starlette is a lightweight ASGI framework and toolkit: routing, middleware, websockets and background tasks. <Link to="fastapi" /> is built on top of it.
+
+Notes to come: ASGI basics, routing, middleware, testing.
+
+* https://www.starlette.io/

--- a/python/testing.mdx
+++ b/python/testing.mdx
@@ -1,7 +1,6 @@
 ---
 title: Testing with Python
 description: "Python testing notes: pytest recipes (parametrized tests) and property-based testing libraries."
-checkedOn: 2026-07-08
 ---
 
 ## Pytest recipes
@@ -21,6 +20,21 @@ import pytest
 def test_eval(test_input, expected):
     assert eval(test_input) == expected
 ```
+
+### Fixtures
+
+```python
+import pytest
+
+@pytest.fixture
+def bridgekeeper():
+    return {"colour": "blue"}
+
+def test_answer(bridgekeeper):
+    assert bridgekeeper["colour"] == "blue"
+```
+
+A fixture is requested by naming it as a test argument; pytest builds it fresh for each test.
 
 ## Other libraries
 


### PR DESCRIPTION
Finalizes the Python section to a deliberate end-state per page (grilled + agreed). You write the prose; this PR is structure + sandbox-verified code + honest metadata, never generated prose.

**Hub + placeholders** (original scope): grouped python/index, fastapi/starlette placeholders (cross-linked).

**Section finalize:**
- `descriptors`: validating example re-themed to `Knight.honour` (matches decorators' Monty Python theme).
- `pandas` (stays indexed): verified recipes added (boolean mask, groupby, merge, value_counts, dates); stale `checkedOn` stripped until you finalize.
- `sqlalchemy` (noindexed until written): ORM section filled with a verified 2.0 declarative example.
- `testing` (noindexed until written): verified pytest fixture example added.
- `bonobo`: honest "not actively maintained" note.
- hub: drops the now-noindexed bokeh/aiohttp from the curated list.

**Theme rule:** full Grail theme on language pages; utility pages get Grail-flavoured data/values only, conventional variable/API names so snippets stay copy-pasteable.

**Verified** with Python 3.13 (pandas 3.0.3, sqlalchemy 2.0.51, pytest 9.1.1). Build clean, 455 unit tests pass. Noindex/sitemap handled in rdnet#59. Curated stubs (jinja2, jupyter, odoo) left as honest short pages. `wtforms` WIP left alone.
