### PR TITLE
docs: drop the Elsewhere section from the now note

### DIFF
--- a/now.mdx
+++ b/now.mdx
@@ -1,7 +1,7 @@
 ---
 title: Now
 description: Building Kongo, an orchestrator for multi-role teams of coding agents. At the piano, pentatonics, quartal voicings and stride.
-checkedOn: 2026-08-06
+checkedOn: 2026-08-07
 hidden: true
 canonical: /
 ---
@@ -36,11 +36,6 @@ A lot at once, and all of it foundation for the rest.
 
 The most important part is none of that. It is the basics: technique, and time
 feeling.
-
-## Elsewhere
-
-Day work goes through [Makersquad](https://www.makersquad.fr/). This wiki grows
-as a side effect.
 
 ---
 


### PR DESCRIPTION
The section said:

> Day work goes through [Makersquad](https://www.makersquad.fr/). This wiki grows as a side effect.

It repeated what the main site already says, in weaker phrasing than either place that says it:

- `/about`: "I run Makersquad, write Python and TypeScript..."
- `/contact`: "Hiring a team goes through Makersquad"

The heading was the other half of the problem: every other section on the page is named for its subject (Kongo, HARP, Music), so "Elsewhere" both broke the pattern and said nothing.

Nothing links to the `#elsewhere` anchor, so no inbound link breaks. `checkedOn` bumped to 2026-08-07. The `description` frontmatter never mentioned Makersquad, so the home page copy is unaffected.